### PR TITLE
#154708606 - fix recipe update not working

### DIFF
--- a/client/components/recipes/UpdateRecipePage.jsx
+++ b/client/components/recipes/UpdateRecipePage.jsx
@@ -66,7 +66,7 @@ class UpdateRecipePage extends React.Component {
   componentWillReceiveProps(nextProps) {
     const {
       name, image, ingredients, direction
-    } = nextProps.recipe;
+    } = nextProps.recipe.recipe;
     this.setState({
       name, image, ingredients, direction
     });


### PR DESCRIPTION
#### Description of Task to be completed?
- This is a bug fix for recipe updates.
When an authenticated user clicks on the edit button to modify their recipe, the recipe is not populated on the page.

#### How should this be manually tested?
- Setup the app following the directions in the `README` file
- Log in as a registered user
- Navigate to `My recipes` from the menu navigation bar
- Click on the `edit` button to view details of the recipe to update

#### Any background context you want to provide?
- User must be authenticated before performing action

#### What are the relevant pivotal tracker stories?
- story type: bug
- story id: 154708606
- story title: fix recipe update not working

#### Screenshots (if appropriate)

<img width="1440" alt="screen shot 2018-01-29 at 1 21 01 am" src="https://user-images.githubusercontent.com/22713293/35489108-bba4df76-0492-11e8-8071-fe589085b412.png">

#### Questions: 
N/A