### PR TITLE
#154716659 - fix search pagination error

### DIFF
--- a/client/action/recipes/recipeSearchAction.js
+++ b/client/action/recipes/recipeSearchAction.js
@@ -18,7 +18,7 @@ export const recipeSearchActionCreator = recipes => ({
 });
 
 export const recipeSearchCount = pageCount => ({
-  get: GET_MY_RECIPES_PAGE_COUNT,
+  type: GET_MY_RECIPES_PAGE_COUNT,
   pageCount
 });
 
@@ -31,7 +31,7 @@ const recipeSearchAction = (searchQuery, page) =>
           alertify.logPosition('bottom right');
           alertify.error(message);
         }
-        dispatch(recipeSearchActionCreator(response.data.recipes));
+
         dispatch(batchActions([
           recipeSearchActionCreator(response.data.recipes),
           recipeSearchCount(response.data.pageCount)

--- a/client/components/recipes/RecipeSearchPage.jsx
+++ b/client/components/recipes/RecipeSearchPage.jsx
@@ -58,7 +58,7 @@ class RecipeSearchPage extends Component {
  */
   onPageChange(current) {
     current.selected += 1;
-    this.props.recipeSearchAction(current.selected);
+    this.props.recipeSearchAction(this.state.searchQuery, current.selected);
   }
 
   /**
@@ -171,7 +171,7 @@ class RecipeSearchPage extends Component {
               </div>
 
             </div>
-
+            <div className="clearfix m-5" />
           </div>
 
         </div>
@@ -186,11 +186,13 @@ RecipeSearchPage.propTypes = {
 };
 
 const mapStateToProps = state => ({
-  recipes: state.recipesReducer.recipes
+  recipes: state.recipesReducer.recipes,
+  pageCount: state.recipesReducer.pageCount
 });
 
 const mapDispatchToProps = dispatch => ({
-  recipeSearchAction: searchQuery => dispatch(recipeSearchAction(searchQuery))
+  recipeSearchAction: (searchQuery, pageCount) =>
+    dispatch(recipeSearchAction(searchQuery, pageCount))
 });
 
 export default connect(

--- a/server/controllers/favoritesController.js
+++ b/server/controllers/favoritesController.js
@@ -109,7 +109,8 @@ const favoritesController = {
       return response.status(400).json({ error });
     }
 
-    const page = request.query.page || 1;
+    const page = Number.isInteger(parseInt(request.query.page, 10))
+  && request.query.page > 0 ? request.query.page : 1;
     const limit = request.query.limit || 9;
     const offset = (page - 1) * limit;
 


### PR DESCRIPTION
#### Description of Task to be completed?
- The user searching for a recipe based on either the recipe name or ingredients should be able to paginate the search results.

#### How should this be manually tested?
- Search for a recipe on the recipe home page using the recipe name or ingredients

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
- story type: bug
- story id: 154716659
- story title: Fix search pagination bug

#### Questions:
N/A